### PR TITLE
fix: Compact class can't inherit from non-copact class

### DIFF
--- a/src/settings.vala
+++ b/src/settings.vala
@@ -1,4 +1,3 @@
-[Compact]
 public class Conf : Object {
     public string audio_device { get; set; }
     public string video_dir { get; set; }


### PR DESCRIPTION
See:
https://gitlab.gnome.org/GNOME/vala/-/commit/34e2c6c5dcf5e89a7bec017bf440bb5e64aa4a77